### PR TITLE
implement logic for 'redirect loader'

### DIFF
--- a/its/application.py
+++ b/its/application.py
@@ -3,7 +3,7 @@
 import logging
 from io import BytesIO
 
-from flask import Flask, Response, abort, request
+from flask import Flask, Response, abort, redirect, request
 from raven.contrib.flask import Sentry
 
 from its.errors import NotFoundError
@@ -12,7 +12,8 @@ from its.optimize import optimize
 from its.pipeline import process_transforms
 from its.settings import MIME_TYPES
 
-from .settings import SENTRY_DSN
+from .settings import NAMESPACES, SENTRY_DSN
+from .util import get_redirect_location
 
 app = Flask(__name__)
 
@@ -22,6 +23,10 @@ if SENTRY_DSN:
 
 
 def process_request(namespace, query, filename):
+    namespace_config = NAMESPACES[namespace]
+    if namespace_config.get("redirect"):
+        location = get_redirect_location(namespace, query, filename)
+        return redirect(location=location, code=301)
 
     try:
         image = loader(namespace, filename)

--- a/its/settings.py
+++ b/its/settings.py
@@ -22,6 +22,11 @@ DEFAULT_NAMESPACES = json.dumps(
         "overlay": {"loader": "file_system", "prefixes": ["test/overlay"]},
         "folders": {"loader": "file_system", "prefixes": [""]},
         "tests": {"loader": "file_system", "folders": ["tests/images"]},
+        "station-images": {
+            "redirect": True,
+            "url": "https://station-service.example.com/station/image-redirects/",
+            "query-param": "url",
+        },
     }
 )
 

--- a/its/tests/test_redirects.py
+++ b/its/tests/test_redirects.py
@@ -16,5 +16,5 @@ class TestRedirects(TestCase):
         assert response.status_code == 301
         assert (
             response.location
-            == "https://station-service.example.com/station/image-redirects/?url=http:localhost/station-images/StationColorProfiles/color/WGBH.png.resize.240x120.png"
+            == "https://station-service.example.com/station/image-redirects/?url=http://localhost/station-images/StationColorProfiles/color/WGBH.png.resize.240x120.png"
         )

--- a/its/tests/test_redirects.py
+++ b/its/tests/test_redirects.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from its.application import app
+
+
+class TestRedirects(TestCase):
+    @classmethod
+    def setUpClass(self):
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+
+    def test_redirect(self):
+        response = self.client.get(
+            "/station-images/StationColorProfiles/color/WGBH.png.resize.240x120.png"
+        )
+        assert response.status_code == 301
+        assert (
+            response.location
+            == "https://station-service.example.com/station/image-redirects/?url=http:localhost/station-images/StationColorProfiles/color/WGBH.png.resize.240x120.png"
+        )

--- a/its/util.py
+++ b/its/util.py
@@ -5,7 +5,7 @@ from .settings import NAMESPACES
 
 def get_redirect_location(namespace, query, filename):
     config = NAMESPACES[namespace]
-    redirect_url = "{url}?{query_param}={scheme}:{host}/{namespace}/{path}".format(
+    redirect_url = "{url}?{query_param}={scheme}://{host}/{namespace}/{path}".format(
         url=config["url"],
         query_param=config["query-param"],
         scheme=request.scheme,

--- a/its/util.py
+++ b/its/util.py
@@ -1,0 +1,23 @@
+from flask import request
+
+from .settings import NAMESPACES
+
+
+def get_redirect_location(namespace, query, filename):
+    config = NAMESPACES[namespace]
+    redirect_url = "{url}?{query_param}={scheme}:{host}/{namespace}/{path}".format(
+        url=config["url"],
+        query_param=config["query-param"],
+        scheme=request.scheme,
+        host=request.host,
+        namespace=namespace,
+        path=filename,
+    )
+    ext = query.pop("format", None)
+    for k, v in query.items():
+        redirect_url = redirect_url + ".{k}.{v}".format(k=k, v=v)
+
+    if ext:
+        redirect_url = redirect_url + "." + ext
+
+    return redirect_url


### PR DESCRIPTION
This is pretty particular to an internal need at PBS - to preserve existing redirects to a "station service" that in turn redirects to canonical image urls for station urls. It's very likely useless to anyone else - we could genericize it if this kind of redirect logic turns out to be useful more broadly.