### PR TITLE
update s3 loader error handling to throw non-404 errors

### DIFF
--- a/its/loaders/s3_loader.py
+++ b/its/loaders/s3_loader.py
@@ -42,7 +42,10 @@ class S3Loader(BaseLoader):
             file_obj = S3Loader.get_fileobj(namespace, filename)
             image = Image.open(file_obj)
 
+            return image
         except ClientError as error:
-            raise NotFoundError("An error occurred: '%s'" % str(error))
+            error_code = error.response["Error"]["Code"]
+            if error_code == 404:
+                raise NotFoundError("An error occurred: '%s'" % str(error))
 
-        return image
+            raise error

--- a/its/loaders/s3_loader.py
+++ b/its/loaders/s3_loader.py
@@ -40,12 +40,14 @@ class S3Loader(BaseLoader):
         """
         try:
             file_obj = S3Loader.get_fileobj(namespace, filename)
-            image = Image.open(file_obj)
-
-            return image
         except ClientError as error:
             error_code = error.response["Error"]["Code"]
+
             if error_code == 404:
                 raise NotFoundError("An error occurred: '%s'" % str(error))
 
             raise error
+
+        image = Image.open(file_obj)
+
+        return image


### PR DESCRIPTION
our current error handling throws 404s given any S3 client error - that's too broad (it hides, for example, permissions errors).

We can use the AWS response metadata that boto3 adds to their custom errors to narrow this - this way, we return 404s if we get a 404 from AWS, but 500s if we get, say a 403 (indicating a config error we shouldn't ignore)