### PR TITLE
enable permissions to multiple s3 buckets

### DIFF
--- a/terraform/access_control.tf
+++ b/terraform/access_control.tf
@@ -47,7 +47,21 @@ resource "aws_iam_role_policy" "its" {
             ],
             "Effect": "Allow",
             "Resource": "${var.parameter_store_path_arn}"
-        },
+        }
+    ],
+    "Version": "2012-10-17"
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "its-s3" {
+  count = "${length(var.s3_buckets)}"
+  name  = "its-${var.environment}-s3-policy-${count.index}"
+  role  = "${aws_iam_role.its_task.name}"
+
+  policy = <<EOF
+{
+    "Statement": [
         {
 
             "Action": [
@@ -55,8 +69,8 @@ resource "aws_iam_role_policy" "its" {
             ],
             "Effect": "Allow",
             "Resource": [
-              "arn:aws:s3:::${var.s3_bucket}/",
-              "arn:aws:s3:::${var.s3_bucket}/*"
+              "arn:aws:s3:::${var.s3_buckets[count.index]}/",
+              "arn:aws:s3:::${var.s3_buckets[count.index]}/*"
             ]
         }
     ],

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -8,9 +8,9 @@ variable "environment" {
   description = "tag for environment, such as prod, staging or qa"
 }
 
-variable "s3_bucket" {
-  type        = "string"
-  description = "name for the S3 bucket ITS will use to store images"
+variable "s3_buckets" {
+  type        = "list"
+  description = "names for the S3 buckets ITS will use to store images"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
we're going to have multiple s3 buckets for different backends, IAM permissions need to allow for that.