### PR TITLE
add s3 document without trailing slash

### DIFF
--- a/terraform/access_control.tf
+++ b/terraform/access_control.tf
@@ -70,6 +70,7 @@ resource "aws_iam_role_policy" "its-s3" {
             ],
             "Effect": "Allow",
             "Resource": [
+              "arn:aws:s3:::${var.s3_buckets[count.index]}",
               "arn:aws:s3:::${var.s3_buckets[count.index]}/",
               "arn:aws:s3:::${var.s3_buckets[count.index]}/*"
             ]


### PR DESCRIPTION
according to https://forums.aws.amazon.com/thread.jspa?threadID=56531, we the correct incantation for listing a bucket does not have a trailing slash on the bucket ARN.