### PR TITLE
Cleanly handle invalid inputs

### DIFF
--- a/its/application.py
+++ b/its/application.py
@@ -3,10 +3,10 @@
 import logging
 from io import BytesIO
 
-from flask import Flask, Response, abort, redirect, request
+from flask import Flask, Response, abort, redirect, request, jsonify
 from raven.contrib.flask import Sentry
 
-from its.errors import NotFoundError
+from its.errors import NotFoundError, ITSTransformError
 from its.loader import loader
 from its.optimize import optimize
 from its.pipeline import process_transforms
@@ -151,6 +151,11 @@ def fit_passport(namespace, filename, width, height, ext):
     query["overlay"] = "passport"
     result = process_request(namespace, query, filename)
     return result
+
+
+@app.errorhandler(ITSTransformError)
+def handle_transform_error(error):
+    return Response(error.message, status=error.status_code)
 
 
 if __name__ == "__main__":

--- a/its/optimize.py
+++ b/its/optimize.py
@@ -39,9 +39,12 @@ def optimize(img, query):
                         new_img = Image.alpha_composite(new_img, img)
                     img = img.convert("RGB")
                 img = optimize_jpg(img, tmp_file, quality)
-            elif ext.lower():
+            elif ext.lower() in ['svg', 'png', 'webp']:
                 # convert from PNG, JPG and WEBP to formats other than JPG
                 img = convert(img, ext, tmp_file)
+
+            else:
+                raise ITSTransformError('ITS Transform Error: Format must be jpeg, svg, png or webp')
 
             # only optimize pngs if quality param is provided
             if img.format == "PNG" and quality is not None:

--- a/its/tests/test_pipeline.py
+++ b/its/tests/test_pipeline.py
@@ -11,6 +11,7 @@ from PIL import Image
 
 from its.optimize import optimize
 from its.pipeline import process_transforms
+import its.errors
 
 
 def get_pixels(image):
@@ -97,6 +98,22 @@ class TestFitTransform(TestCase):
         fit_transform(test_image, query)
         fit_transform.assert_called_with(test_image, query)
 
+    def test_invalid_crop_size(self):
+        test_image = Image.open(self.img_dir / "test.png")
+        test_image.info["filename"] = "test.png"
+        query = {"fit": "5x0"}
+
+        with self.assertRaises(its.errors.ITSTransformError):
+            process_transforms(test_image, query)
+
+    def test_invalid_focal_percentages(self):
+        test_image = Image.open(self.img_dir / "test.png")
+        test_image.info["filename"] = "test.png"
+        query = {"fit": "100x100x150x150"}
+
+        with self.assertRaises(its.errors.ITSTransformError):
+            process_transforms(test_image, query)
+
 
 class TestResizeTransform(TestCase):
     @classmethod
@@ -131,6 +148,25 @@ class TestResizeTransform(TestCase):
         comparison = compare_pixels(expected, actual)
         self.assertGreaterEqual(comparison, self.threshold)
 
+    def test_invalid_resize(self):
+        test_image = Image.open(self.img_dir / "test.png")
+        query = {
+            "resize": "100"
+        }
+        
+        with self.assertRaises(its.errors.ITSTransformError):
+            process_transforms(test_image, query)
+
+    def test_resize_format(self):
+        test_image = Image.open(self.img_dir / "test.png")
+        query = {
+            "resize": "100x100",
+            "format": "foo"
+        }
+        
+        with self.assertRaises(its.errors.ITSTransformError):
+            result = process_transforms(test_image, query)
+            optimize(result, query)
 
 class TestImageResults(TestCase):
     @classmethod

--- a/its/transformations/fit.py
+++ b/its/transformations/fit.py
@@ -62,17 +62,14 @@ class FitTransform(BaseTransform):
                 + "The focus point can either be defined in the query or in the image filename."
             )
 
-        if (focal_x < 0 or focal_x > 100) or (focal_y < 0 or focal_y > 100):
-            # make sure focal args are percentages
-            raise ITSTransformError(error="Focus arguments should be between 0 and 100")
-        else:
+        if focal_x in range(0, 101) and focal_y in range(0, 101) and crop_height != 0:
             try:
                 focal_x = focal_x / 100
                 focal_y = focal_y / 100
                 img = ImageOps.fit(
                     img,
                     (crop_width, crop_height),
-                    Image.ANTIALIAS,
+                    method=Image.ANTIALIAS,
                     centering=(focal_x, focal_y),
                 )
 
@@ -86,5 +83,12 @@ class FitTransform(BaseTransform):
                     focal_y,
                 )
                 raise error
+
+        elif crop_height == 0:
+            raise ITSTransformError(error="Crop height must be greater than 0")
+
+        else:
+            # make sure focal args are percentages
+            raise ITSTransformError(error="Focus arguments should be between 0 and 100")
 
         return img

--- a/its/transformations/resize.py
+++ b/its/transformations/resize.py
@@ -15,7 +15,10 @@ class ResizeTransform(BaseTransform):
         Resizes input image while maintaining aspect ratio.
         """
 
-        width, height = resize_size
+        if len(resize_size) == 2:
+            width, height = resize_size
+        else:
+            raise ITSTransformError("Missing width or height. Both width and height")
 
         if img.width == 0 or img.height == 0:
             raise ITSTransformError(

--- a/its/transformations/resize.py
+++ b/its/transformations/resize.py
@@ -18,12 +18,14 @@ class ResizeTransform(BaseTransform):
         if len(resize_size) == 2:
             width, height = resize_size
         else:
-            raise ITSTransformError("Missing width or height. Both width and height")
+            raise ITSTransformError(
+                "Missing width or height. Both width and height are required"
+            )
 
         if img.width == 0 or img.height == 0:
             raise ITSTransformError(
                 "Invalid arguments supplied to Resize Transform."
-                + "Input image cannot have zero width nor zero height."
+                "Input image cannot have zero width nor zero height."
             )
 
         try:
@@ -31,18 +33,18 @@ class ResizeTransform(BaseTransform):
             height = int(height) if height != "" else None
         except ValueError:
             raise ITSTransformError(
-                "Invalid arguments supplied to Resize Transform."
-                + "Resize takes WWxHH, WWx, or xHH,"
-                + " where WW is the requested width and "
-                + "HH is the requested height. Both must be integers."
+                "Invalid arguments supplied to Resize Transform. "
+                "Resize takes WWxHH, WWx, or xHH,"
+                " where WW is the requested width and "
+                "HH is the requested height. Both must be integers."
             )
 
         if width is None and height is None:
             raise ITSTransformError(
                 "Invalid arguments supplied to Resize Transform."
-                + "Resize takes WWxHH, WWx, or xHH,"
-                + " where WW is the requested width and "
-                + "HH is the requested height. Both must be integers."
+                "Resize takes WWxHH, WWx, or xHH,"
+                " where WW is the requested width and "
+                "HH is the requested height. Both must be integers."
             )
 
         if width is None and height:


### PR DESCRIPTION
500s are currently thrown when users provide inputs which are nonsensical. Examples:
https://9ik9vu2xwl.execute-api.us-east-1.amazonaws.com/dev/default/test/foo001.jpg?format=foo
https://9ik9vu2xwl.execute-api.us-east-1.amazonaws.com/dev/default/test/foo001.jpg?resize=100
https://9ik9vu2xwl.execute-api.us-east-1.amazonaws.com/dev/default/test/foo001.jpg?fit=10x0

These changes provide clear error messages when these inputs are provided.