### PR TITLE
reduce version number to pre-1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+# warning: under active development
+
+This application is under active development and likely to change further before stabilizing.
+
 # serverless-its
-ITS rewrite
 
 ITS (Image Transform Service) performs transformations on images by accepting transform requests in the form of query strings. 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="its",
-    version="2.0.0",
+    version="0.0.1",
     py_modules=["its"],
     author="",
     author_email="",


### PR DESCRIPTION
 and publish notice that ITS is under active development.

Currently, it's a bit confusing that we have `version == 2.0.0`, even though the app is under heavy development and is still basically "beta software" (for example, see #101)

Improvements to language, etc welcome.