### PR TITLE
Bugfix/handle http backend 404

### DIFF
--- a/its/loaders/http.py
+++ b/its/loaders/http.py
@@ -30,8 +30,18 @@ class HTTPLoader(BaseLoader):
                 url = filename
             else:
                 url = "https://{}".format(filename)
-            # create an empty bytes object to store the image bytes in
-            file_obj = BytesIO(requests.get(url).content)
+            response = requests.get(url)
+
+            if response.status_code == 200:
+                # create an empty bytes object to store the image bytes in
+                file_obj = BytesIO(response.content)
+            elif response.status_code in [403, 404]:
+                raise NotFoundError(
+                    "404 from {namespace} http backend for {filename}".format(
+                        namespace=namespace, filename=filename
+                    )
+                )
+
         else:
             raise NotFoundError("Namespace {} is not configured.".format(namespace))
 

--- a/its/loaders/http.py
+++ b/its/loaders/http.py
@@ -3,7 +3,7 @@ from io import BytesIO
 import requests
 from PIL import Image
 
-from ..errors import NotFoundError
+from ..errors import ITSLoaderError, NotFoundError
 from ..settings import NAMESPACES
 from .base import BaseLoader
 
@@ -25,27 +25,31 @@ class HTTPLoader(BaseLoader):
         params = NAMESPACES[namespace][HTTPLoader.parameter_name]
         intersect = set(params).intersection(prefixes)
 
-        if intersect:
-            if filename.startswith("http"):
-                url = filename
-            else:
-                url = "https://{}".format(filename)
-            response = requests.get(url)
-
-            if response.status_code == 200:
-                # create an empty bytes object to store the image bytes in
-                file_obj = BytesIO(response.content)
-            elif response.status_code in [403, 404]:
-                raise NotFoundError(
-                    "404 from {namespace} http backend for {filename}".format(
-                        namespace=namespace, filename=filename
-                    )
-                )
-
-        else:
+        if not intersect:
             raise NotFoundError("Namespace {} is not configured.".format(namespace))
 
-        return file_obj
+        if filename.startswith("http"):
+            url = filename
+        else:
+            url = "https://{}".format(filename)
+        response = requests.get(url)
+
+        if response.status_code in [403, 404]:
+            raise NotFoundError(
+                "404 from http backend for {namespace}/{filename}".format(
+                    namespace=namespace, filename=filename
+                )
+            )
+        elif response.status_code != 200:
+            raise ITSLoaderError(
+                "{code} from http backend for {namespace}/{filename}".format(
+                    code=response.status_code, namespace=namespace, filename=filename
+                ),
+                status_code=500,
+            )
+
+        # create an empty bytes object to store the image bytes in
+        return BytesIO(response.content)
 
     @staticmethod
     def load_image(namespace, filename):

--- a/its/tests/fixtures/cassettes/test_http_backend_404
+++ b/its/tests/fixtures/cassettes/test_http_backend_404
@@ -1,0 +1,22 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.19.1]
+    method: GET
+    uri: https://s3.amazonaws.com/pbs.merlin.cdn.prod/some-fake-thing.jpg
+  response:
+    body: {string: '<?xml version="1.0" encoding="UTF-8"?>
+
+        <Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>5B1033CF46A4D55F</RequestId><HostId>3WlDqqUp50ht67jmmLVVkyiG3o+iqEAUZR1lx1ruDdHHm7voLu003pGdeq7HePnvo5FDRBnq11s=</HostId></Error>'}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Tue, 26 Jun 2018 17:25:54 GMT']
+      Server: [AmazonS3]
+      x-amz-id-2: [3WlDqqUp50ht67jmmLVVkyiG3o+iqEAUZR1lx1ruDdHHm7voLu003pGdeq7HePnvo5FDRBnq11s=]
+      x-amz-request-id: [5B1033CF46A4D55F]
+    status: {code: 403, message: Forbidden}
+version: 1

--- a/its/tests/test_http_backend.py
+++ b/its/tests/test_http_backend.py
@@ -22,3 +22,10 @@ class TestRedirects(TestCase):
     def test_self_referential_http_backend_use(self):
         response = self.client.get("/merlin/localhost/tests/images/test.png")
         assert response.status_code == 200
+
+    @test_vcr.use_cassette()
+    def test_http_backend_404(self):
+        response = self.client.get(
+            "/merlin/s3.amazonaws.com/pbs.merlin.cdn.prod/some-fake-thing.jpg.fit.646x246.jpg"
+        )
+        assert response.status_code == 404


### PR DESCRIPTION
this will cleanly handle 403s or 404s from http backends - before this change, we instead pass an empty bytes object to PIL, which throws an error that looks like `cannot identify image file <_io.BytesIO object>`