### PR TITLE
refactor: optimize.optimize should never get a BytesIO object

### DIFF
--- a/its/optimize.py
+++ b/its/optimize.py
@@ -1,10 +1,9 @@
 import subprocess
 import uuid
-from io import BytesIO
 from math import floor
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from PIL import Image, ImageFile
 from PIL.JpegImagePlugin import JpegImageFile
@@ -17,13 +16,7 @@ from .errors import ITSClientError, ITSTransformError
 ImageFile.MAXBLOCK = 2 ** 20  # for JPG progressive saving
 
 
-def optimize(
-    img: Union[Image.Image, BytesIO], query: Dict[str, str]
-) -> Union[Image.Image, BytesIO]:
-
-    if isinstance(img, BytesIO):
-        return img
-
+def optimize(img: Image.Image, query: Dict[str, str]) -> Image.Image:
     ext = (
         query["format"] if "format" in query else img.format.lower()
     )  # the return format


### PR DESCRIPTION
the only time we use the optimize function is in application.py,
after checking that we're not sending it a BytesIO object.

allowing the optimize function to accept and return BytesIO objects complicates
subsequent logic, which assumes that the returned value has image-specific
methods like format and save.

simpler to disallow sending svgs to the optimize function, which
has no business getting them anyway.