### PR TITLE
use exec in entrypoint scripts, should help containers stop faster

### DIFF
--- a/scripts/docker/server/dev-server.sh
+++ b/scripts/docker/server/dev-server.sh
@@ -8,4 +8,4 @@ FLASK_ENV=development
 export FLASK_APP
 export FLASK_ENV
 
-pipenv run flask run --host=0.0.0.0
+exec pipenv run flask run --host=0.0.0.0

--- a/scripts/docker/server/run-server.sh
+++ b/scripts/docker/server/run-server.sh
@@ -17,11 +17,11 @@ source larson_json_to_vars $APP_CONFIG_PATH
 
 if [ -z "$ITS_NEWRELIC_LICENSE" ]; then
     # no newrelic license key configured, run uwsgi plain
-    uwsgi --ini $UWSGI_CONFIG_PATH
+    exec uwsgi --ini $UWSGI_CONFIG_PATH
 else
     # newrelic license key available, generate config file then
     # run uwsgi in newrelic wrapper
     confd -onetime -backend file -file $APP_CONFIG_PATH
-    NEW_RELIC_CONFIG_FILE=/etc/its/newrelic.ini newrelic-admin run-program \
+    exec NEW_RELIC_CONFIG_FILE=/etc/its/newrelic.ini newrelic-admin run-program \
         uwsgi --ini $UWSGI_CONFIG_PATH
 fi


### PR DESCRIPTION
using `exec` ensures that we hand off process one to our main application, which helps signals propagate correctly. Before:

```
$ docker exec serverless-its_server_1 ps
PID   USER     TIME   COMMAND
    1 its        0:00 {dev-server.sh} /bin/bash ./scripts/docker/server/dev-server.sh
    7 its        0:02 {flask} /home/its/.local/share/virtualenvs/its-mkXEKwMr/bin/python3 /home/its/.local/share/virtualenvs/its-mkXEKwMr/bin/flask run --host=0.0.0.0
   34 its        0:01 /home/its/.local/share/virtualenvs/its-mkXEKwMr/bin/python3 /home/its/.local/share/virtualenvs/its-mkXEKwMr/bin/flask run --host=0.0.0.0
   53 its        0:00 ps
```
after:
```
$ docker exec serverless-its_server_1 ps
PID   USER     TIME   COMMAND
    1 its        0:02 {flask} /home/its/.local/share/virtualenvs/its-mkXEKwMr/bin/python3 /home/its/.local/share/virtualenvs/its-mkXEKwMr/bin/flask run --host=0.0.0.0
   33 its        0:01 /home/its/.local/share/virtualenvs/its-mkXEKwMr/bin/python3 /home/its/.local/share/virtualenvs/its-mkXEKwMr/bin/flask run --host=0.0.0.0
   47 its        0:00 ps
```
