### PR TITLE
scale down under 30% CPU usage

### DIFF
--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -153,7 +153,7 @@ resource "aws_cloudwatch_metric_alarm" "its_web_cpu_low" {
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "10"
+  threshold           = "30"
   alarm_actions       = ["${aws_appautoscaling_policy.its_web_scale_down.arn}"]
 
   dimensions {


### PR DESCRIPTION
10 percent, our current threshold, seems a bit too conservative - under very low load, we tend to hover under 20 percent, and could safely shed containers.