### PR TITLE
increase memory allocation for ECS task: 800->1600 MiB

### DIFF
--- a/terraform/web-task-definition.json
+++ b/terraform/web-task-definition.json
@@ -18,7 +18,8 @@
         "name": "PARAMETER_PATH",
         "value": "${parameter_path}"
     }],
-    "memory": 800,
+    "memory": 1600,
+    "memoryReservation": 800,
     "name": "web",
     "portMappings": [{
         "containerPort": 5000,


### PR DESCRIPTION
we notice some oom errors in production - as a first pass, we could try blindly doubling memory allocation to see if this problem gets solved.